### PR TITLE
Resolve focus by uuid in SceneRigV3 and Model, slim selectionStore to…

### DIFF
--- a/src/app/components/three/cameras/SceneRigV3.js
+++ b/src/app/components/three/cameras/SceneRigV3.js
@@ -146,7 +146,7 @@ const SceneRigV3 = ({
     const xOffset = offsetPositionRef.current.x + sine;
     const yOffset = offsetPositionRef.current.y + (-2 * sine);
     const zOffset = offsetPositionRef.current.z + sine;
-    const focusedName = useSelection.getState().selection.focusedName;
+    const focusedUUID = useSelection.getState().selection.focusedUUID;
 
     if (targetIndexRef.current >= positions.length || targetIndexRef.current < 0) {
       targetIndexRef.current = 0;
@@ -154,10 +154,7 @@ const SceneRigV3 = ({
 
     const promotedEntries = Object.values(promoted);
     let nextPosition = positions[0];
-    const focusTargetExists = focusedName !== null && focusedName?.length > 0;
-    const focusedEntry = focusTargetExists
-      ? promotedEntries.find(e => e.target.name === focusedName)
-      : undefined;
+    const focusedEntry = focusedUUID ? promoted[focusedUUID] : undefined;
     const focusedIndex = focusedEntry?.index ?? -1;
     const isManualOverrideActive = elapsedTime < manualOverrideTimeRef.current;
 

--- a/src/app/components/three/models/Model.js
+++ b/src/app/components/three/models/Model.js
@@ -8,6 +8,7 @@ import { easing } from 'maath';
 import useMaterial, { defaultMeshPhysicalMaterialConfig } from '@stores/materialStore';
 import useSelection from '@stores/selectionStore';
 import { eulerDistance, EPSILON_3e3, EPSILON_10e4, RotationAnimationModes, PositionAnimationModes, wrap } from '@utils/animationUtils';
+import { getProjectByNodeName } from '@configs/globals';
 import cameraConfigs from '@configs/cameraConfigs';
 
 const { OFFSET_CAMERA_POSITION: [, , cameraOffsetDistance] } = cameraConfigs;
@@ -25,6 +26,7 @@ const Model = (props) => {
   } = props;
 
   const camera = useThree((state) => state.camera);
+  const project = getProjectByNodeName(nodeName);
 
   const {
     nodes: {
@@ -54,6 +56,20 @@ const Model = (props) => {
   const targetMaterialRef = useRef(null);
 
   useEffect(() => { if (meshRef.current && typeof onMeshReady === 'function') onMeshReady(meshRef.current) }, [onMeshReady]);
+
+  useEffect(() => {
+    if (!nodeName) return;
+
+    const tryFillUUID = () => {
+      const { focusedName, focusedUUID } = useSelection.getState().selection;
+      if (focusedName === nodeName && focusedUUID === null && meshRef.current) {
+        useSelection.getState().setFocusedUUID(meshRef.current.uuid);
+      }
+    };
+
+    tryFillUUID();
+    return useSelection.subscribe(tryFillUUID);
+  }, [nodeName]);
 
   useLayoutEffect(() => {
     if (meshRef.current) {
@@ -228,11 +244,11 @@ const Model = (props) => {
     const matState = useMaterial.getState();
     const texturesReady = matState.texturesInitialized?.length > 0;
     const { selection } = useSelection.getState();
-    const selectedAndFocused = selection.focusedName?.length > 0 && selection.focusedName === nodeName;
+    const selectedAndFocused = selection.focusedUUID !== null && selection.focusedUUID === meshRef.current?.uuid;
 
     updateCameraRelativeScale(cam, clampedDelta, false);
 
-    const positionMode = !selectedAndFocused || !selection.sceneData.animatePosition ? PositionAnimationModes.DISABLED : PositionAnimationModes.ENABLED;
+    const positionMode = !selectedAndFocused || !project?.sceneData.animatePosition ? PositionAnimationModes.DISABLED : PositionAnimationModes.ENABLED;
     updatePositionAnimation(
       positionMode,
       0,
@@ -241,10 +257,10 @@ const Model = (props) => {
       clampedDelta
     );
 
-    const rotationMode = !selectedAndFocused || !selection.sceneData.animateRotation
+    const rotationMode = !selectedAndFocused || !project?.sceneData.animateRotation
       ? RotationAnimationModes.MODE_IDLE
-      : (selection.sceneData.defaultRotationAnimationActive ? RotationAnimationModes.MODE_TURNTABLE : RotationAnimationModes.MODE_MANUAL);
-    updateRotationAnimation(rotationMode, selection.sceneData.deltaRotation, clampedDelta);
+      : (selection.defaultRotationAnimationActive ? RotationAnimationModes.MODE_TURNTABLE : RotationAnimationModes.MODE_MANUAL);
+    updateRotationAnimation(rotationMode, selection.deltaRotation, clampedDelta);
 
     if (!texturesReady) return;
 
@@ -275,7 +291,7 @@ const Model = (props) => {
       }
     }
 
-    if (selection.sceneData.animateMaterial && targetMaterialRef.current) {
+    if (project?.sceneData.animateMaterial && targetMaterialRef.current) {
       easeMaterialProperties(targetMaterialRef.current, clampedDelta);
       updateDeterministicMaterialProperties(targetMaterialRef.current);
     }

--- a/src/app/components/three/models/Model.js
+++ b/src/app/components/three/models/Model.js
@@ -58,7 +58,7 @@ const Model = (props) => {
 
   useEffect(() => { if (meshRef.current && typeof onMeshReady === 'function') onMeshReady(meshRef.current) }, [onMeshReady]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!nodeName) return;
 
     const tryFillUUID = () => {

--- a/src/app/components/three/models/Model.js
+++ b/src/app/components/three/models/Model.js
@@ -8,13 +8,15 @@ import { easing } from 'maath';
 import useMaterial, { defaultMeshPhysicalMaterialConfig } from '@stores/materialStore';
 import useSelection from '@stores/selectionStore';
 import { eulerDistance, EPSILON_3e3, EPSILON_10e4, RotationAnimationModes, PositionAnimationModes, wrap } from '@utils/animationUtils';
-import { getProjectByNodeName } from '@configs/globals';
 import cameraConfigs from '@configs/cameraConfigs';
 
 const { OFFSET_CAMERA_POSITION: [, , cameraOffsetDistance] } = cameraConfigs;
 
 const Model = (props) => {
   const {
+    animateMaterial = false,
+    animatePosition = false,
+    animateRotation = false,
     fileData: { nodeName = '', url = '' } = {},
     materials: { defaultMaterialID = 'matte_black', materialIDs = [], } = {},
     onClick = undefined,
@@ -26,7 +28,6 @@ const Model = (props) => {
   } = props;
 
   const camera = useThree((state) => state.camera);
-  const project = getProjectByNodeName(nodeName);
 
   const {
     nodes: {
@@ -248,7 +249,7 @@ const Model = (props) => {
 
     updateCameraRelativeScale(cam, clampedDelta, false);
 
-    const positionMode = !selectedAndFocused || !project?.sceneData.animatePosition ? PositionAnimationModes.DISABLED : PositionAnimationModes.ENABLED;
+    const positionMode = !selectedAndFocused || !animatePosition ? PositionAnimationModes.DISABLED : PositionAnimationModes.ENABLED;
     updatePositionAnimation(
       positionMode,
       0,
@@ -257,7 +258,7 @@ const Model = (props) => {
       clampedDelta
     );
 
-    const rotationMode = !selectedAndFocused || !project?.sceneData.animateRotation
+    const rotationMode = !selectedAndFocused || !animateRotation
       ? RotationAnimationModes.MODE_IDLE
       : (selection.defaultRotationAnimationActive ? RotationAnimationModes.MODE_TURNTABLE : RotationAnimationModes.MODE_MANUAL);
     updateRotationAnimation(rotationMode, selection.deltaRotation, clampedDelta);
@@ -291,7 +292,7 @@ const Model = (props) => {
       }
     }
 
-    if (project?.sceneData.animateMaterial && targetMaterialRef.current) {
+    if (animateMaterial && targetMaterialRef.current) {
       easeMaterialProperties(targetMaterialRef.current, clampedDelta);
       updateDeterministicMaterialProperties(targetMaterialRef.current);
     }

--- a/src/app/components/three/scenes/SceneComposer.js
+++ b/src/app/components/three/scenes/SceneComposer.js
@@ -125,6 +125,9 @@ const SceneComposer = () => {
         return (
           <Model
             key={nodeName}
+            animateMaterial={sceneData.animateMaterial}
+            animatePosition={sceneData.animatePosition}
+            animateRotation={sceneData.animateRotation}
             fileData={sceneData.fileData}
             materials={sceneData.materials}
             onClick={handleClick}

--- a/src/app/components/three/scenes/SceneComposer.js
+++ b/src/app/components/three/scenes/SceneComposer.js
@@ -4,7 +4,7 @@ import { startTransition, useCallback, useEffect, useMemo, useRef } from 'react'
 import * as THREE from 'three';
 import { useThree } from '@react-three/fiber';
 import { EffectComposer, N8AO, Vignette } from '@react-three/postprocessing';
-import { projects } from '@configs/globals';
+import { projects, getProjectByNodeName } from '@configs/globals';
 import cameraConfigs from '@configs/cameraConfigs';
 import useSelection from '@stores/selectionStore';
 import MaterialTextureInitializer from '../textures/MaterialTextureInitializer';
@@ -57,10 +57,10 @@ const SceneComposer = () => {
 
     if (useSelection.getState().selection.focusedUUID === clickedUUID) return;
 
-    const index = projects.findIndex(({ sceneData: { fileData: { nodeName = '' } = {} } = {} }) => nodeName === clickedName);
-    if (index < 0) return;
+    const project = getProjectByNodeName(clickedName);
+    if (!project) return;
 
-    const materialID = projects[index].sceneData.materials.defaultMaterialID;
+    const materialID = project.sceneData.materials.defaultMaterialID;
     startTransition(() => { setFocused(clickedName, materialID, clickedUUID) });
   }, [setFocused]);
 

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import useSelection from '@stores/selectionStore';
 import { getSlugFromName } from '@utils/slug';
-import { projects } from '@configs/globals';
+import { getProjectByNodeName } from '@configs/globals';
 
 const EASE_OUT = [0.215, 0.61, 0.355, 1];
 const EASE_IN_OUT = [0.76, 0, 0.24, 1];
@@ -41,13 +41,10 @@ const createVariants = (reduceMotion) => {
 
 const SelectionDisplayModal = () => {
   const focusedName = useSelection((state) => state.selection.focusedName);
-  const setSelection = useSelection((state) => state.setSelection);
   const shouldReduceMotion = useReducedMotion();
   const variants = createVariants(shouldReduceMotion);
 
-  const focusedProject = projects.find(({ sceneData: { fileData: { nodeName = '' } = {} } = {} }) => nodeName === focusedName);
-
-  const handleClick = () => { if (focusedProject) setSelection({ ...focusedProject }) };
+  const focusedProject = focusedName ? getProjectByNodeName(focusedName) : null;
 
   const {
     UIData: {
@@ -83,7 +80,6 @@ const SelectionDisplayModal = () => {
                   href={route}
                   rel='noopener noreferrer'
                   className='pointer-events-auto'
-                  onClick={handleClick}
                 >
                   <div className='cursor-pointer'> View Details </div>
                 </Link>

--- a/src/app/projects/_components/ProjectDataModal.js
+++ b/src/app/projects/_components/ProjectDataModal.js
@@ -1,10 +1,9 @@
 'use client';
 
-import React, { memo, useLayoutEffect, useMemo, useState } from 'react';
+import React, { memo, useLayoutEffect, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import CloseFullscreenIcon from '@mui/icons-material/CloseFullscreen';
-import { projects } from '@configs/globals';
-import { getProjectFromSlug } from '@utils/slug';
+import { getProjectBySlug } from '@configs/globals';
 import useMaterial from '@stores/materialStore';
 import useSelection from '@stores/selectionStore';
 import AutoModeIcon from '@mui/icons-material/AutoMode';
@@ -128,23 +127,17 @@ const ProjectDataModal = ({ slug, entryPoint }) => {
   const router = useRouter();
   const pathname = usePathname();
   const materials = useMaterial((state) => state.materials);
-  const selection = useSelection((state) => state.selection);
-  const setSelectionStore = useSelection((state) => state.setSelection);
+  const focusedMaterialID = useSelection((state) => state.selection.focusedMaterialID);
+  const defaultRotationAnimationActive = useSelection((state) => state.selection.defaultRotationAnimationActive);
+  const setFocused = useSelection((state) => state.setFocused);
   const setMaterialID = useSelection((state) => state.setMaterialID);
 
   const toggleDefaultRotationAnimation = useSelection.getState().toggleDefaultRotationAnimation;
-  const defaultRotationAnimationActive = useSelection.getState().selection.sceneData.defaultRotationAnimationActive;
   const setRotation = useSelection.getState().setRotation;
 
   const [expanded, setExpanded] = useState(false);
 
-  const project = useMemo(() => {
-    if (!slug?.length) return null;
-
-    return getProjectFromSlug(slug, projects);
-  }, [slug]);
-
-  const projectData = project || selection;
+  const project = slug?.length ? getProjectBySlug(slug) : null;
 
   const {
     UIData: {
@@ -166,42 +159,18 @@ const ProjectDataModal = ({ slug, entryPoint }) => {
         z: rz = 0
       } = {},
     } = {},
-  } = projectData || {};
+  } = project || {};
 
-  const selectedMaterialID = useMemo(() =>
-    selection?.focusedMaterialID?.length ? selection.focusedMaterialID : defaultMaterialID
-    , [selection.focusedMaterialID, defaultMaterialID]);
+  const selectedMaterialID = focusedMaterialID?.length ? focusedMaterialID : defaultMaterialID;
 
-  // Hydration guard that handles direct visits to /projects/[slug] directly or refreshing browser tab. 
-  // In both cases selectionStore initializes to initialState.
   useLayoutEffect(() => {
     if (!project) return;
 
-    const {
-      UIData: {
-        displayName: projectDisplayName,
-      } = {},
-      sceneData: {
-        fileData: {
-          nodeName: projectNodeName,
-        } = {},
-        materials: {
-          defaultMaterialID: projectDefaultMaterialID,
-        }
-      } = {},
-    } = project;
+    const nodeName = project.sceneData.fileData.nodeName;
+    if (useSelection.getState().selection.focusedName === nodeName) return;
 
-    const selectionDisplayName = useSelection.getState().selection?.UIData?.displayName || null;
-
-    if (!selectionDisplayName || selectionDisplayName !== projectDisplayName) {
-      const update = {
-        ...project,
-        focusedName: projectNodeName,
-        materialID: projectDefaultMaterialID,
-      };
-      setSelectionStore(update);
-    }
-  }, [project, setSelectionStore]);
+    setFocused(nodeName, project.sceneData.materials.defaultMaterialID, null);
+  }, [project, setFocused]);
 
   const navigateToRoot = () => {
     reset();

--- a/src/app/stores/selectionStore.js
+++ b/src/app/stores/selectionStore.js
@@ -4,76 +4,19 @@ const initialState = {
   focusedName: null,
   focusedUUID: null,
   focusedMaterialID: '',
-  UIData: {
-    care: '',
-    description: '',
-    dimensions: '',
-    displayName: '',
-    materialSpecs: '',
-    shortDescription: '',
-    weight: '',
-  },
-  sceneData: {
-    animateMaterial: true,
-    defaultRotationAnimationActive: true,
-    animatePosition: false,
-    animateRotation: true,
-    fileData: { nodeName: '', url: '', },
-    materials: { defaultMaterialID: '', materialIDs: [], },
-    position: {},
-    rotation: { x: 0, y: 0, z: 0 },
-    deltaRotation: { x: 0, y: 0, z: 0 },
-    rotationSpeed: 1,
-    scale: 1,
-  },
+  defaultRotationAnimationActive: true,
+  deltaRotation: { x: 0, y: 0, z: 0 },
 };
 
 function isolateSelection(selection) {
   return {
     ...selection,
-    UIData: {
-      ...selection.UIData,
-    },
-    sceneData: {
-      ...selection.sceneData,
-      fileData: { ...selection.sceneData.fileData },
-      materials: {
-        ...selection.sceneData.materials,
-        materialIDs: [...selection.sceneData.materials.materialIDs],
-      },
-      position: { ...selection.sceneData.position },
-      rotation: { ...selection.sceneData.rotation },
-      deltaRotation: { ...selection.sceneData.deltaRotation },
-    },
+    deltaRotation: { ...selection.deltaRotation },
   };
 }
 
-const selectionStore = (set, get) => ({
+const selectionStore = (set) => ({
   selection: initialState,
-
-  setSelection: (selected) =>
-    set((state) => ({
-      selection: {
-        ...isolateSelection(selected),
-        focusedName: selected?.focusedName ?? state.selection?.focusedName ?? null,
-      },
-    })),
-
-  setFocusedName: (name) =>
-    set((state) => ({
-      selection: {
-        ...isolateSelection(state.selection),
-        focusedName: name,
-      },
-    })),
-
-  setMaterialID: (id) =>
-    set((state) => ({
-      selection: {
-        ...isolateSelection(state.selection),
-        focusedMaterialID: id,
-      },
-    })),
 
   setFocused: (name, materialID, uuid) =>
     set((state) => ({
@@ -85,30 +28,39 @@ const selectionStore = (set, get) => ({
       },
     })),
 
-  toggleAnimateRotation: () =>
-    set((state) => {
-      const cloned = isolateSelection(state.selection);
-      cloned.sceneData.animateRotation = !state.selection.sceneData.animateRotation;
-      return { selection: cloned };
-    }),
+  setFocusedUUID: (uuid) =>
+    set((state) => ({
+      selection: {
+        ...isolateSelection(state.selection),
+        focusedUUID: uuid,
+      },
+    })),
+
+  setMaterialID: (id) =>
+    set((state) => ({
+      selection: {
+        ...isolateSelection(state.selection),
+        focusedMaterialID: id,
+      },
+    })),
 
   setRotation: (vals) =>
     set((state) => {
       const cloned = isolateSelection(state.selection);
-      cloned.sceneData.deltaRotation = { ...vals };
-      cloned.sceneData.defaultRotationAnimationActive = false;
+      cloned.deltaRotation = { ...vals };
+      cloned.defaultRotationAnimationActive = false;
       return { selection: cloned };
     }),
 
-    toggleDefaultRotationAnimation: () =>
-      set((state) => {
-        const cloned = isolateSelection(state.selection);
-        cloned.sceneData.defaultRotationAnimationActive = !state.selection.sceneData.defaultRotationAnimationActive;
-        cloned.sceneData.deltaRotation = { ...initialState.sceneData.deltaRotation };
-        return { selection: cloned };
-      }),
+  toggleDefaultRotationAnimation: () =>
+    set((state) => {
+      const cloned = isolateSelection(state.selection);
+      cloned.defaultRotationAnimationActive = !state.selection.defaultRotationAnimationActive;
+      cloned.deltaRotation = { ...initialState.deltaRotation };
+      return { selection: cloned };
+    }),
 
-    reset: () => set({ selection: isolateSelection(initialState) }),
+  reset: () => set({ selection: isolateSelection(initialState) }),
 });
 
 const useSelection = create(selectionStore);

--- a/src/lib/configs/globals.js
+++ b/src/lib/configs/globals.js
@@ -1,3 +1,5 @@
+import { getSlugFromName } from '@utils/slug';
+
 export const envImageUrl = '/para_ground_glare_fog.hdr';
 export const envColor = '#bcbcbc';
 export const projects = [
@@ -86,3 +88,14 @@ export const projects = [
     },
   },
 ];
+
+const _projectsByNodeName = Object.fromEntries(
+  projects.map((project) => [project.sceneData.fileData.nodeName, project])
+);
+
+const _projectsBySlug = Object.fromEntries(
+  projects.map((project) => [getSlugFromName(project.UIData.displayName), project])
+);
+
+export const getProjectByNodeName = (nodeName) => _projectsByNodeName[nodeName] ?? null;
+export const getProjectBySlug = (slug) => _projectsBySlug[slug] ?? null;

--- a/src/lib/utils/slug.js
+++ b/src/lib/utils/slug.js
@@ -8,16 +8,3 @@ export const getSlugFromName = (name) => {
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '');
 };
-
-export const getProjectFromSlug = (slug, projects) => {
-  if (!slug || !projects) return null;
-
-  return projects.find(
-    ({
-      UIData: {
-        displayName
-      } = {}
-    }) =>
-      getSlugFromName(displayName) === slug
-  );
-};


### PR DESCRIPTION
You already fixed most of the UUID stuff so this code is more of a refactor of the selectionStore than a fix for the original ticket.

Note that the globals state is a steady object reference so we don't need to `useMemo` or `useCallback` anywhere we use it. We can still achieve that in a world where it comes from the server by using react-query or a similar library.